### PR TITLE
Update organs and tissues array rendering in credential template

### DIFF
--- a/schemas/Pledge.json
+++ b/schemas/Pledge.json
@@ -98,8 +98,8 @@
         "bloodGroup": "{{personalDetails.bloodGroup}}",
         "pledge": {
           "type": "OrganPledge",
-          "organs": "{{pledgeDetails.organs}}",
-          "tissues": "{{pledgeDetails.tissues}}",
+          "organs": "{{#each pledgeDetails.organs}}{{#if @index}}, {{/if}}{{this}}{{/each}}",
+          "tissues": "{{#each pledgeDetails.tissues}}{{#if @index}}, {{/if}}{{this}}{{/each}}",
           "additionalOrgans": "{{pledgeDetails.other}}"
         },
         "emergency": {


### PR DESCRIPTION
The organs and tissues are getting rendered as string in credential template. Previously the string dint have spaces between the items. This caused issues in rendering the values on certificate and verification page. This is been fixed using a custom iteration. https://github.com/Sunbird-RC/prototypes/issues/135