### PR TITLE
RC_175: Integrated Digit_Id_gen service for unique Noto ID generation

### DIFF
--- a/backend/donor-service/configs/config.js
+++ b/backend/donor-service/configs/config.js
@@ -5,6 +5,7 @@ const CLIENT_ID = process.env.CLIENT_ID;
 const CLIENT_SECRET = process.env.CLIENT_SECRET;
 const REGISTRY_URL = process.env.REGISTRY_URL;
 const CERTIFICATE_API_URL = process.env.CERTIFICATE_API_URL;
+const DIGIT_IDGEN_URL = process.env.DIGIT_IDGEN_URL;
 const EXPIRE_PROFILE = process.env.EXPIRE_PROFILE;
 const ESIGN_ESP_URL = process.env.ESIGN_ESP_URL;
 const ESIGN_ESP_PDF_URL = process.env.ESIGN_ESP_PDF_URL;
@@ -46,5 +47,6 @@ module.exports = {
     NOTIFY_TEMPLATE_ID,
     ABHA_CLIENT_URL,
     UPDATE_TEMPLATE_ID,
-    UNPLEDGE_TEMPLATE_ID
+    UNPLEDGE_TEMPLATE_ID,
+    DIGIT_IDGEN_URL
 }

--- a/backend/donor-service/main.js
+++ b/backend/donor-service/main.js
@@ -146,7 +146,7 @@ app.get('/health', async(req, res) => {
     res.status(200).send({status: 'UP'});
 });
 
-async function getUniqueFromIDgen (entityName, registrationCategory) {
+async function getUniqueIdFromIdGenService (entityName, registrationCategory) {
     let data = getFormatedRequest(entityName, registrationCategory);
     const response = await axios({
         method: 'post',
@@ -172,7 +172,7 @@ async function generateNottoIdUsingDigit(entityName) {
     if (registrationCategory === null) {
         throw new Error(`Entity ${entityName} not supported`)
     }
-    const uniqueId = await getUniqueFromIDgen(entityName, registrationCategory);
+    const uniqueId = await getUniqueIdFromIdGenService(entityName, registrationCategory);
     return uniqueId; 
 }
 

--- a/backend/donor-service/main.js
+++ b/backend/donor-service/main.js
@@ -172,7 +172,7 @@ async function generateNottoIdUsingDigit(entityName) {
     if (registrationCategory === null) {
         throw new Error(`Entity ${entityName} not supported`)
     }
-    const uniqueId = await getNottoFromIDgen(entityName, registrationCategory);
+    const uniqueId = await getUniqueFromIDgen(entityName, registrationCategory);
     return uniqueId; 
 }
 

--- a/backend/donor-service/main.js
+++ b/backend/donor-service/main.js
@@ -214,7 +214,7 @@ app.post('/register/:entityName', async(req, res) => {
     const profile = getProfileFromUserAndRedis(profileFromReq, profileFromRedis);
     const entityName = req.params.entityName;
     try {
-        profile.identificationDetails.nottoId = await generateNottoId(entityName);
+        profile.identificationDetails.nottoId = await generateNottoIdUsingDigit(entityName);
         const inviteReponse = (await axios.post(`${config.REGISTRY_URL}/api/v1/${entityName}/invite`, profile)).data;
         await incrementNottoId(entityName);
         const abha = profileFromReq.identificationDetails.abha;

--- a/backend/donor-service/utils/utils.js
+++ b/backend/donor-service/utils/utils.js
@@ -66,8 +66,28 @@ const convertToSocialShareResponse = (entityName, userData) => {
         }, {});
 }
 
+const getFormatedRequest = ( entityName, entityCategory) =>  {
+    return {
+        "RequestInfo": {
+            "apiId": "donorRegistry",
+            "ver": "13",
+            "ts": 0,
+            "msgId": "getUniqueId"
+        },
+        "idRequests": [
+            {
+                "idName": `sunbird.rc.${entityName}`,
+                "tenantId": `s.rc.${entityName}`,
+                "format": `${entityCategory}[cy:yy][SEQ_${entityCategory}_SRC_NUM]`
+            }
+        ]
+    }
+   
+}
+
 module.exports = {
     calculateAge,
     getErrorObject,
     convertToSocialShareResponse,
+    getFormatedRequest
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -334,3 +334,18 @@ services:
       NOTIFY_TEMPLATE_ID: ${NOTIFY_TEMPLATE_ID}
       UPDATE_TEMPLATE_ID: ${UPDATE_TEMPLATE_ID}
       UNPLEDGE_TEMPLATE_ID: ${UNPLEDGE_TEMPLATE_ID}
+  DigitIdGenration-service:
+    image: sreejith/idgen:latest
+    ports:
+      - "8088:8088"
+    depends_on:
+      db:
+        condition: service_healthy  
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/registry
+      SPRING_DATASOURCE_USERNAME: postgres
+      SPRING_DATASOURCE_PASSWORD: postgres
+      SPRING_FLYWAY_URL : jdbc:postgresql://db:5432/registry
+      SPRING_FLYWAY_USER: postgres
+      SPRING_FLYWAY_PASSWORD: postgres
+      ID_SEQUENCE_PADDING: 7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -336,7 +336,7 @@ services:
       UPDATE_TEMPLATE_ID: ${UPDATE_TEMPLATE_ID}
       UNPLEDGE_TEMPLATE_ID: ${UNPLEDGE_TEMPLATE_ID}
   digit-id-genration-service:
-    image: sreejith/idgen:latest
+    image: sreejithk1903/idgen:latest
     ports:
       - "8088:8088"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -313,6 +313,7 @@ services:
       REDIS_URL: ${REDIS_URL}
       REGISTRY_URL: ${REGISTRY_URL}
       CERTIFICATE_API_URL: http://certificate-api:8078
+      DIGIT_IDGEN_URL : http://digit-id-genration-service:8088
       ABHA_CLIENT_URL: ${ABHA_CLIENT_URL}
       CLIENT_ID: ${CLIENT_ID}
       CLIENT_SECRET: ${CLIENT_SECRET}
@@ -334,7 +335,7 @@ services:
       NOTIFY_TEMPLATE_ID: ${NOTIFY_TEMPLATE_ID}
       UPDATE_TEMPLATE_ID: ${UPDATE_TEMPLATE_ID}
       UNPLEDGE_TEMPLATE_ID: ${UNPLEDGE_TEMPLATE_ID}
-  DigitIdGenration-service:
+  digit-id-genration-service:
     image: sreejith/idgen:latest
     ports:
       - "8088:8088"


### PR DESCRIPTION
This PR leverages the DIGIT-OSS Id generation service ( https://github.com/egovernments/DIGIT-OSS/tree/master/core-services/egov-idgen ) to generate a unique number based on the format that we feed to it. We had to make a few changes in the Digit-oss id gens service to make it compatible with the donor registry service for NOTO ID generation (https://github.com/egovernments/DIGIT-OSS/compare/master...Sreejit-K:DIGIT-OSS:sunbirdRC_UniqueID ). 

- Added a new logic for Notto ID generation. 
- changes in the docker-compose file for integrating egov-idgen sevice

Issue - https://github.com/Sunbird-RC/prototypes/issues/175